### PR TITLE
Fix Django ticket #33160 (PR #14918)

### DIFF
--- a/django_psycopg3/base.py
+++ b/django_psycopg3/base.py
@@ -330,10 +330,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
 
     @contextmanager
     def _nodb_cursor(self):
+        cursor = None
         try:
             with super()._nodb_cursor() as cursor:
                 yield cursor
         except (Database.DatabaseError, WrappedDatabaseError):
+            if cursor is not None:
+                raise
             warnings.warn(
                 "Normally Django will use a connection to the 'postgres' database "
                 "to avoid running initialization queries against the production "


### PR DESCRIPTION
This fixes one Django test suite failure:
```
======================================================================
ERROR: test_nodb_cursor_reraise_exceptions (backends.postgresql.tests.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/.local/lib/python3.8/site-packages/django_psycopg3/base.py", line 335, in _nodb_cursor
    yield cursor
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/backends/postgresql/tests.py", line 111, in test_nodb_cursor_reraise_exceptions
    raise DatabaseError('exception')
django.db.utils.DatabaseError: exception

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/backends/postgresql/tests.py", line 111, in test_nodb_cursor_reraise_exceptions
    raise DatabaseError('exception')
  File "/usr/lib/python3.8/contextlib.py", line 131, in __exit__
    self.gen.throw(type, value, traceback)
  File "/home/runner/.local/lib/python3.8/site-packages/django_psycopg3/base.py", line 337, in _nodb_cursor
    warnings.warn(
RuntimeWarning: Normally Django will use a connection to the 'postgres' database to avoid running initialization queries against the production database when it's not needed (for example, when running tests). Django was unable to create a connection to the 'postgres' database and will use the first PostgreSQL database instead.
```