### PR TITLE
Fix Django ticket #33279 (PR #15078)

### DIFF
--- a/django_psycopg3/operations.py
+++ b/django_psycopg3/operations.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping, Sequence
 
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
+from django.db.backends.utils import split_tzname_delta
 
 from psycopg.sql import SQL, Literal
 
@@ -47,10 +48,10 @@ class DatabaseOperations(BaseDatabaseOperations):
         return "DATE_TRUNC('%s', %s)" % (lookup_type, field_name)
 
     def _prepare_tzname_delta(self, tzname):
-        if '+' in tzname:
-            return tzname.replace('+', '-')
-        elif '-' in tzname:
-            return tzname.replace('-', '+')
+        tzname, sign, offset = split_tzname_delta(tzname)
+        if offset:
+            sign = '-' if sign == '+' else '+'
+            return f'{tzname}{sign}{offset}'
         return tzname
 
     def _convert_field_to_tz(self, field_name, tzname):


### PR DESCRIPTION
This fixes two Django test suite errors:
```
======================================================================
ERROR: test_extract_func_with_timezone_minus_no_offset (db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests) [backports.zoneinfo.ZoneInfo(key='Asia/Ust-Nera')]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 568, in execute
    raise ex.with_traceback(None)
psycopg.errors.InvalidParameterValue: time zone "Asia/Ust+Nera" not recognized

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/db_functions/datetime/test_extract_trunc.py", line 1226, in test_extract_func_with_timezone_minus_no_offset
    utc_model = qs.get()
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 437, in get
    num = len(clone)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 262, in __len__
    self._fetch_all()
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 1358, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 51, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/sql/compiler.py", line 1234, in execute_sql
    cursor.execute(sql, params)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 568, in execute
    raise ex.with_traceback(None)
django.db.utils.DataError: time zone "Asia/Ust+Nera" not recognized

======================================================================
ERROR: test_extract_func_with_timezone_minus_no_offset (db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests) [<DstTzInfo 'Asia/Ust-Nera' LMT+9:33:00 STD>]
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 568, in execute
    raise ex.with_traceback(None)
psycopg.errors.InFailedSqlTransaction: current transaction is aborted, commands ignored until end of transaction block

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/db_functions/datetime/test_extract_trunc.py", line 1226, in test_extract_func_with_timezone_minus_no_offset
    utc_model = qs.get()
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 437, in get
    num = len(clone)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 262, in __len__
    self._fetch_all()
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 1358, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/query.py", line 51, in __iter__
    results = compiler.execute_sql(chunked_fetch=self.chunked_fetch, chunk_size=self.chunk_size)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/models/sql/compiler.py", line 1234, in execute_sql
    cursor.execute(sql, params)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 76, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/utils.py", line 85, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 568, in execute
    raise ex.with_traceback(None)
django.db.utils.InternalError: current transaction is aborted, commands ignored until end of transaction block
```