### PR TITLE
Implement `operations.on_conflict_suffix_sql()`

### DIFF
--- a/django_psycopg3/operations.py
+++ b/django_psycopg3/operations.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping, Sequence
 from django.conf import settings
 from django.db.backends.base.operations import BaseDatabaseOperations
 from django.db.backends.utils import split_tzname_delta
+from django.db.models.constants import OnConflict
 
 from psycopg.sql import SQL, Literal
 
@@ -271,8 +272,22 @@ class DatabaseOperations(BaseDatabaseOperations):
             prefix += ' (%s)' % ', '.join('%s %s' % i for i in extra.items())
         return prefix
 
-    def ignore_conflicts_suffix_sql(self, ignore_conflicts=None):
-        return 'ON CONFLICT DO NOTHING' if ignore_conflicts else super().ignore_conflicts_suffix_sql(ignore_conflicts)
+    def on_conflict_suffix_sql(self, fields, on_conflict, update_fields, unique_fields):
+        if on_conflict == OnConflict.IGNORE:
+            return "ON CONFLICT DO NOTHING"
+        if on_conflict == OnConflict.UPDATE:
+            return "ON CONFLICT(%s) DO UPDATE SET %s" % (
+                ", ".join(map(self.quote_name, unique_fields)),
+                ", ".join(
+                    [
+                        f"{field} = EXCLUDED.{field}"
+                        for field in map(self.quote_name, update_fields)
+                    ]
+                ),
+            )
+        return super().on_conflict_suffix_sql(
+            fields, on_conflict, update_fields, unique_fields
+        )
 
 
 def compose(query, params):


### PR DESCRIPTION
See https://github.com/django/django/commit/0f6946495a8ec955b471ca1baaf408ceb53d4796

This should fix 12 occurrencs of error:
```
ERROR: test_add (many_to_many.tests.ManyToManyTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "django_repo/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 555, in execute
    raise ex.with_traceback(None)
psycopg.errors.UniqueViolation: duplicate key value violates unique constraint "many_to_many_article_pub_article_id_publication_i_caad31f7_uniq"
DETAIL:  Key (article_id, publication_id)=(6, 3) already exists.

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "django_repo/tests/many_to_many/tests.py", line 53, in test_add
    a6.publications.add(self.p3)
  File "django_repo/django/db/models/fields/related_descriptors.py", line 1069, in add
    self._add_items(
  File "django_repo/django/db/models/fields/related_descriptors.py", line 1290, in _add_items
    self.through._default_manager.using(db).bulk_create(
  File "django_repo/django/db/models/query.py", line 682, in bulk_create
    returned_columns = self._batched_insert(
  File "django_repo/django/db/models/query.py", line 1586, in _batched_insert
    self._insert(
  File "django_repo/django/db/models/query.py", line 1552, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "django_repo/django/db/models/sql/compiler.py", line 1667, in execute_sql
    cursor.execute(sql, params)
  File "django_repo/django/db/backends/utils.py", line 67, in execute
    return self._execute_with_wrappers(
  File "django_repo/django/db/backends/utils.py", line 80, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "django_repo/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "django_repo/django/db/utils.py", line 91, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "django_repo/django/db/backends/utils.py", line 89, in _execute
    return self.cursor.execute(sql, params)
  File "/home/runner/.local/lib/python3.8/site-packages/psycopg/cursor.py", line 555, in execute
    raise ex.with_traceback(None)
django.db.utils.IntegrityError: duplicate key value violates unique constraint "many_to_many_article_pub_article_id_publication_i_caad31f7_uniq"
DETAIL:  Key (article_id, publication_id)=(6, 3) already exists.
```