### PR TITLE
Implement Django commit django/django@9ac3ef59

### DIFF
--- a/django_psycopg3/base.py
+++ b/django_psycopg3/base.py
@@ -145,6 +145,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     # Map the initial connection state
     ctx_templates = {}
 
+    def get_database_version(self):
+        """
+        Return a tuple of the database's version.
+        E.g. for pg_version 120004, return (12, 4).
+        """
+        return divmod(self.pg_version, 10000)
+
     def get_connection_params(self):
         settings_dict = self.settings_dict
         # None may be used to connect to the default 'postgres' db
@@ -250,6 +257,7 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         return ctx
 
     def init_connection_state(self):
+        super().init_connection_state()
         timezone_changed = self.ensure_timezone()
         if timezone_changed:
             # Commit after setting the time zone (see #17062)

--- a/django_psycopg3/features.py
+++ b/django_psycopg3/features.py
@@ -6,6 +6,7 @@ from django.utils.functional import cached_property
 
 
 class DatabaseFeatures(BaseDatabaseFeatures):
+    minimum_database_version = (12,)
     allows_group_by_selected_pks = True
     can_return_columns_from_insert = True
     can_return_rows_from_bulk_insert = True


### PR DESCRIPTION
https://github.com/django/django/commit/9ac3ef59

Also, update minimum Postgres version supported to 12 in sync with
Django main branch / 4.2 release cycle changes.

Fixes error
```
======================================================================
ERROR: test_get_database_version (backends.postgresql.tests.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/backends/postgresql/tests.py", line 346, in test_get_database_version
    self.assertEqual(new_connection.get_database_version(), (11, 9))
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/db/backends/base/base.py", line 191, in get_database_version
    raise NotImplementedError(
NotImplementedError: subclasses of BaseDatabaseWrapper may require a get_database_version() method.
```

and failure
```
======================================================================
FAIL: test_check_database_version_supported (backends.postgresql.tests.Tests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/usr/lib/python3.8/unittest/mock.py", line 1325, in patched
    return func(*newargs, **newkeywargs)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/tests/backends/postgresql/tests.py", line 352, in test_check_database_version_supported
    connection.check_database_version_supported()
  File "/usr/lib/python3.8/contextlib.py", line 120, in __exit__
    next(self.gen)
  File "/home/runner/work/django-psycopg3-backend/django-psycopg3-backend/django_repo/django/test/testcases.py", line 799, in _assert_raises_or_warns_cm
    yield cm
AssertionError: NotSupportedError not raised
```

when running Django test suite.